### PR TITLE
Python 3 compatibility.

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -12,10 +12,11 @@ from .immutable_dict import ImmutableDict
 from .edn_lex import Keyword, Symbol
 from .edn_parse import TaggedElement
 
-if sys.version_info[0] == 3:
+if sys.version_info[0] >= 3:
     long = int
     basestring = str
     unicode = str
+    unichr = chr
 
 # proper unicode escaping
 # see http://stackoverflow.com/a/24519338


### PR DESCRIPTION
Fixed Python 3 unichr/chr incompatibility. Changed Python version detection from exactly equal to 3 to greater than or equal to 3.