### PR TITLE
Add support to dump '#inst' with microseconds

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -73,7 +73,7 @@ def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING):
         return '{{{}}}'.format(seq(itertools.chain.from_iterable(obj.items()),
             string_encoding))
     elif isinstance(obj, datetime.datetime):
-        return '#inst "{}"'.format(pyrfc3339.generate(obj))
+        return '#inst "{}"'.format(pyrfc3339.generate(obj, microseconds=True))
     elif isinstance(obj, datetime.date):
         return '#inst "{}"'.format(obj.isoformat())
     elif isinstance(obj, uuid.UUID):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name="edn_format",
-      version="0.5.8",
+      version="0.5.9",
       author="Swaroop C H",
       author_email="swaroop@swaroopch.com",
       description="EDN format reader and writer in Python",

--- a/tests.py
+++ b/tests.py
@@ -204,7 +204,7 @@ class EdnTest(unittest.TestCase):
             '[1 "abc" true :ghi]',
             '(1 "abc" true :ghi)',
             '{"a" 2}',
-            '#inst "1985-04-12T23:20:50Z"',
+            '#inst "1985-04-12T23:20:50.000000Z"',
             '#inst "2011-10-09"',
             '#uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"',
             '#date "19/07/1984"',


### PR DESCRIPTION
`pyrfc3339` already supports it, just missing an arg.

This is important for, e.g., Datomic inter-op.