### PR TITLE
Add a sort_keys optional keyword argument to dumps

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -42,13 +42,17 @@ def unicode_escape(string):
         return ESCAPE_DCT[match.group(0)]
     return '"' + ESCAPE.sub(replace, string) + '"'
 
-def seq(obj, string_encoding = DEFAULT_INPUT_ENCODING,
-             keyword_keys = False):
-    return ' '.join([udump(i, string_encoding=string_encoding,
-                              keyword_keys=keyword_keys) for i in obj])
+def seq(obj, **kwargs):
+    return ' '.join([udump(i, **kwargs) for i in obj])
 
 def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
                keyword_keys = False):
+
+    kwargs = {
+        "string_encoding": string_encoding,
+        "keyword_keys": keyword_keys,
+    }
+
     if obj is None:
         return 'nil'
     elif isinstance(obj, bool):
@@ -67,19 +71,17 @@ def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
     elif isinstance(obj, basestring):
         return unicode_escape(obj)
     elif isinstance(obj, tuple):
-        return '({})'.format(seq(obj, string_encoding, keyword_keys))
+        return '({})'.format(seq(obj, **kwargs))
     elif isinstance(obj, list):
-        return '[{}]'.format(seq(obj, string_encoding, keyword_keys))
+        return '[{}]'.format(seq(obj, **kwargs))
     elif isinstance(obj, set) or isinstance(obj, frozenset):
-        return '#{{{}}}'.format(seq(obj, string_encoding, keyword_keys))
+        return '#{{{}}}'.format(seq(obj, **kwargs))
     elif isinstance(obj, dict) or isinstance(obj, ImmutableDict):
         pairs = obj.items()
         if keyword_keys:
             pairs = ((Keyword(k) if isinstance(k, (bytes, basestring)) else k, v) for k, v in pairs)
 
-        return '{{{}}}'.format(seq(itertools.chain.from_iterable(pairs),
-                                   string_encoding,
-                                   keyword_keys))
+        return '{{{}}}'.format(seq(itertools.chain.from_iterable(pairs), **kwargs))
     elif isinstance(obj, datetime.datetime):
         return '#inst "{}"'.format(pyrfc3339.generate(obj, microseconds=True))
     elif isinstance(obj, datetime.date):

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -46,11 +46,13 @@ def seq(obj, **kwargs):
     return ' '.join([udump(i, **kwargs) for i in obj])
 
 def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
-               keyword_keys = False):
+               keyword_keys = False,
+               sort_keys = False):
 
     kwargs = {
         "string_encoding": string_encoding,
         "keyword_keys": keyword_keys,
+        "sort_keys": sort_keys,
     }
 
     if obj is None:
@@ -78,6 +80,8 @@ def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
         return '#{{{}}}'.format(seq(obj, **kwargs))
     elif isinstance(obj, dict) or isinstance(obj, ImmutableDict):
         pairs = obj.items()
+        if sort_keys:
+            pairs = sorted(pairs, key=lambda p: str(p[0]))
         if keyword_keys:
             pairs = ((Keyword(k) if isinstance(k, (bytes, basestring)) else k, v) for k, v in pairs)
 
@@ -96,9 +100,11 @@ def udump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
 
 def dump(obj, string_encoding = DEFAULT_INPUT_ENCODING,
               output_encoding = DEFAULT_OUTPUT_ENCODING,
-              keyword_keys = False):
+              keyword_keys = False,
+              sort_keys = False):
     outcome = udump(obj, string_encoding=string_encoding,
-                         keyword_keys=keyword_keys)
+                         keyword_keys=keyword_keys,
+                         sort_keys=sort_keys)
     if __PY3:
         return outcome
     return outcome.encode(output_encoding)

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ import datetime
 import pytz
 import unittest
 from uuid import uuid4
+from collections import OrderedDict
 from edn_format import edn_lex, edn_parse, \
     loads, dumps, Keyword, Symbol, TaggedElement, ImmutableDict, add_tag
 
@@ -63,6 +64,9 @@ class EdnTest(unittest.TestCase):
 
     def check_parse(self, expected_output, actual_input):
         self.assertEqual(expected_output, edn_parse.parse(actual_input))
+
+    def check_dumps(self, expected_output, actual_input, **kw):
+        self.assertEqual(expected_output, dumps(actual_input, **kw))
 
     def test_parser(self):
         self.check_parse(1,
@@ -270,6 +274,20 @@ class EdnTest(unittest.TestCase):
         self.assertEqual(
                 {Keyword("a"): {Keyword("b"): 2}, 3: 4},
                 loads(dumps({Keyword("a"): {"b": 2}, 3: 4}, keyword_keys=True)))
+
+    def test_sort_keys(self):
+            cases = (
+                ('{"a" 4 "b" 5 "c" 3}', OrderedDict([("c", 3), ("b", 5), ("a", 4)])),
+                ('{1 0 2 0 "a" 0}', {"a": 0, 1: 0, 2: 0}),
+                ('[{"a" 1 "b" 1}]', [OrderedDict([("b", 1), ("a", 1)])]),
+            )
+
+            for expected, data in cases:
+                self.check_dumps(expected, data, sort_keys=True)
+
+            self.check_dumps('{:a 1 :b 1 :c 1 :d 1}',
+                             {"a": 1, "d": 1, "b": 1, "c": 1},
+                             sort_keys=True, keyword_keys=True)
 
 
 class EdnInstanceTest(unittest.TestCase):


### PR DESCRIPTION
This mirrors `json.dumps` from the Python standard library. If this is true, map keys are sorted in the output. This makes diffs simpler because the keys order in a map is not "random" anymore.