### PR TITLE
Raise custom exceptions on syntax errors

### DIFF
--- a/edn_format/__init__.py
+++ b/edn_format/__init__.py
@@ -5,9 +5,11 @@ from .edn_lex import Keyword, Symbol
 from .edn_parse import parse as loads
 from .edn_parse import add_tag, remove_tag, TaggedElement
 from .edn_dump import dump as dumps
+from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 
 __all__ = (
+    'EDNDecodeError',
     'ImmutableDict',
     'Keyword',
     'Symbol',

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -12,6 +12,7 @@ import sys
 
 import ply.lex
 
+from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 
 
@@ -204,7 +205,7 @@ def t_FLOAT(t):
     if 'e' in t.value or 'E' in t.value:
         matches = re.search('[eE]([+-]?\d+)M?$', t.value)
         if matches is None:
-            raise SyntaxError('Invalid float : {}'.format(t.value))
+            raise EDNDecodeError('Invalid float : {}'.format(t.value))
         e_value = int(matches.group(1))
     if t.value.endswith('M'):
         ctx = decimal.getcontext()
@@ -251,7 +252,7 @@ def t_SYMBOL(t):
 
 
 def t_error(t):
-    raise SyntaxError(
+    raise EDNDecodeError(
         "Illegal character '{c}' with lexpos {p} in the area of ...{a}...".format(
             c=t.value[0], p=t.lexpos, a=t.value[0:100]))
 

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -9,6 +9,7 @@ import ply.yacc
 import pyrfc3339
 
 from .edn_lex import tokens, lex
+from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 
 
@@ -93,7 +94,7 @@ def p_map(p):
     """map : MAP_START expressions MAP_OR_SET_END"""
     terms = p[2]
     if len(terms) % 2 != 0:
-        raise SyntaxError('Even number of terms required for map')
+        raise EDNDecodeError('Even number of terms required for map')
     # partition terms in pairs
     p[0] = ImmutableDict(dict([terms[i:i + 2] for i in range(0, len(terms), 2)]))
 
@@ -144,9 +145,9 @@ def p_expression_tagged_element(p):
 
 def p_error(p):
     if p is None:
-        raise SyntaxError('EOF Reached')
+        raise EDNDecodeError('EOF Reached')
     else:
-        raise SyntaxError(p)
+        raise EDNDecodeError(p)
 
 
 def parse(text, input_encoding='utf-8'):

--- a/edn_format/exceptions.py
+++ b/edn_format/exceptions.py
@@ -1,0 +1,6 @@
+# -*- coding: UTF-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+class EDNDecodeError(ValueError):
+    pass

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,8 @@ import unittest
 import pytz
 
 from edn_format import edn_lex, edn_parse, \
-    loads, dumps, Keyword, Symbol, TaggedElement, ImmutableDict, add_tag
+    loads, dumps, Keyword, Symbol, TaggedElement, ImmutableDict, add_tag, \
+    EDNDecodeError
 
 
 class ConsoleTest(unittest.TestCase):
@@ -258,6 +259,10 @@ class EdnTest(unittest.TestCase):
             ch = chr(i)
             edn_data = "\\{}".format(ch)
             self.assertEqual(ch, loads(edn_data), edn_data)
+
+    def test_exceptions(self):
+        with self.assertRaises(EDNDecodeError):
+            loads("{")
 
     def test_keyword_keys(self):
         unchanged = (


### PR DESCRIPTION
The current code raises `SyntaxError` on syntax errors. The problem with that is it’s impossible to catch EDN syntax errors and not other syntax errors. Also, `SyntaxError` is [raised by the Python parser](https://docs.python.org/3/library/exceptions.html#SyntaxError) on bad code.

This PR adds a new `exceptions` namespace with a single class, `EDNDecodeError`, that inherits from `ValueError`. This mimicks Python’s `json.decoder.JSONDecodeError`.

Note that this is a breaking change, since code that catches `SyntaxError`s to catch EDN issues won’t work anymore if it’s not changed to catch `EDNDecodeError`s instead.