### PR TITLE
Use mutable data structures to improve parsing time

### DIFF
--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import sys
 import uuid
+from collections import deque
 
 import ply.yacc
 import pyrfc3339
@@ -78,23 +79,24 @@ def p_map(p):
     if len(terms) % 2 != 0:
         raise EDNDecodeError('Even number of terms required for map')
     # partition terms in pairs
-    p[0] = ImmutableDict(dict([terms[i:i + 2] for i in range(0, len(terms), 2)]))
+    p[0] = ImmutableDict((terms[i], terms[i+1]) for i in range(0, len(terms), 2))
 
 
 def p_discarded_expressions(p):
     """discarded_expressions : DISCARD_TAG expression discarded_expressions
                              |"""
-    p[0] = []
+    p[0] = deque([])
 
 
 def p_expressions_expression_expressions(p):
     """expressions : expression expressions"""
-    p[0] = [p[1]] + p[2]
+    p[2].appendleft(p[1])
+    p[0] = p[2]
 
 
 def p_expressions_empty(p):
     """expressions : discarded_expressions"""
-    p[0] = []
+    p[0] = deque([])
 
 
 def p_expression(p):

--- a/edn_format/immutable_list.py
+++ b/edn_format/immutable_list.py
@@ -8,7 +8,7 @@ import copy as _copy
 class ImmutableList(collections.Sequence, collections.Hashable):
     def __init__(self, wrapped_list, copy=True):
         """Returns an immutable version of the given list. Optionally creates a shallow copy."""
-        self._list = _copy.copy(wrapped_list) if copy else wrapped_list
+        self._list = list(wrapped_list) if copy else wrapped_list
         self._hash = None
 
     def __repr__(self):


### PR DESCRIPTION
Previously a list was used to hold the intermediate results during parsing of "expressions", but each expression was prepended by copying, Fixing this takes parsing from quadratic to linear time.

This performance problem means that it takes some of our (very large) files over half an hour to be loaded in Python, against less than half a minute in Clojure.