### PR TITLE
add support for unicode char literals

### DIFF
--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -21,7 +21,7 @@ if sys.version_info[0] == 3:
     long = int
     basestring = str
     unicode = str
-    _bytes = lambda s: bytes(s, 'utf-8')
+    def _bytes(s): return bytes(s, 'utf-8')
 else:
     _bytes = bytes
 
@@ -177,7 +177,8 @@ def t_WHITESPACE(t):
 
 
 def t_CHAR(t):
-    # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space or unicode word chars
+    # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space
+    # or unicode word chars
     r"(\\u[0-9A-Fa-f]{4}|\\[!-~\w])"
     t.value = (t.value[1] if len(t.value) == 2 else _bytes(t.value).decode('raw_unicode_escape'))
     return t

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -21,7 +21,9 @@ if sys.version_info[0] == 3:
     long = int
     basestring = str
     unicode = str
-_bytes = (bytes if sys.version_info[0] == 2 else lambda s: bytes(s, 'utf-8'))
+    _bytes = lambda s: bytes(s, 'utf-8')
+else:
+    _bytes = bytes
 
 
 ESCAPE_SEQUENCE_RE = re.compile(r'''

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -177,7 +177,7 @@ def t_WHITESPACE(t):
 
 
 def t_CHAR(t):
-    # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space
+    # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space or unicode word chars
     r"(\\u[0-9A-Fa-f]{4}|\\[!-~\w])"
     t.value = (t.value[1] if len(t.value) == 2 else _bytes(t.value).decode('raw_unicode_escape'))
     return t

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -21,6 +21,7 @@ if sys.version_info[0] == 3:
     long = int
     basestring = str
     unicode = str
+_bytes = (bytes if sys.version_info[0] == 2 else lambda s: bytes(s, 'utf-8'))
 
 
 ESCAPE_SEQUENCE_RE = re.compile(r'''
@@ -174,9 +175,9 @@ def t_WHITESPACE(t):
 
 
 def t_CHAR(t):
-    # from "!" to "~" = all printable ASCII chars except the space
-    r"(\\[!-~])"
-    t.value = t.value[1]
+    # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space
+    r"(\\u[0-9A-Fa-f]{4}|\\[!-~\w])"
+    t.value = (t.value[1] if len(t.value) == 2 else _bytes(t.value).decode('raw_unicode_escape'))
     return t
 
 

--- a/tests.py
+++ b/tests.py
@@ -107,6 +107,10 @@ class EdnTest(unittest.TestCase):
                          r"\c")
         self.check_parse("\n",
                          r"\newline")
+        self.check_parse(u"Σ",
+                         u"\\Σ")
+        self.check_parse(u"λ",
+                         r"\u03bB")
         self.check_parse(Keyword("abc"),
                          ":abc")
         self.check_parse([Keyword("abc"), 1, True, None],

--- a/tests.py
+++ b/tests.py
@@ -339,18 +339,18 @@ class EdnTest(unittest.TestCase):
                 loads(dumps({Keyword("a"): {"b": 2}, 3: 4}, keyword_keys=True)))
 
     def test_sort_keys(self):
-            cases = (
-                ('{"a" 4 "b" 5 "c" 3}', OrderedDict([("c", 3), ("b", 5), ("a", 4)])),
-                ('{1 0 2 0 "a" 0}', {"a": 0, 1: 0, 2: 0}),
-                ('[{"a" 1 "b" 1}]', [OrderedDict([("b", 1), ("a", 1)])]),
-            )
+        cases = (
+            ('{"a" 4 "b" 5 "c" 3}', OrderedDict([("c", 3), ("b", 5), ("a", 4)])),
+            ('{1 0 2 0 "a" 0}', {"a": 0, 1: 0, 2: 0}),
+            ('[{"a" 1 "b" 1}]', [OrderedDict([("b", 1), ("a", 1)])]),
+        )
 
-            for expected, data in cases:
-                self.check_dumps(expected, data, sort_keys=True)
+        for expected, data in cases:
+            self.check_dumps(expected, data, sort_keys=True)
 
-            self.check_dumps('{:a 1 :b 1 :c 1 :d 1}',
-                             {"a": 1, "d": 1, "b": 1, "c": 1},
-                             sort_keys=True, keyword_keys=True)
+        self.check_dumps('{:a 1 :b 1 :c 1 :d 1}',
+                         {"a": 1, "d": 1, "b": 1, "c": 1},
+                         sort_keys=True, keyword_keys=True)
 
     def test_sort_sets(self):
         def misordered_set_sequence():


### PR DESCRIPTION
As per new examples in tests, this includes both `\Σ` and `\u03bB` variations