### PR TITLE
Add an edn_parse.tag decorator, + docs and tests on tags

### DIFF
--- a/edn_format/__init__.py
+++ b/edn_format/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .edn_lex import Keyword, Symbol
 from .edn_parse import parse as loads
-from .edn_parse import add_tag, remove_tag, TaggedElement
+from .edn_parse import add_tag, remove_tag, tag, TaggedElement
 from .edn_dump import dump as dumps
 from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
@@ -20,4 +20,5 @@ __all__ = (
     'dumps',
     'loads',
     'remove_tag',
+    'tag',
 )

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -34,14 +34,44 @@ class TaggedElement(object):
         raise NotImplementedError("To be implemented by derived classes")
 
 
-def add_tag(tag_name, tag_class):
+def add_tag(tag_name, tag_fn_or_class):
+    """
+    Add a custom tag handler.
+    """
     assert isinstance(tag_name, basestring)
-    _serializers[tag_name] = tag_class
+    _serializers[tag_name] = tag_fn_or_class
 
 
 def remove_tag(tag_name):
+    """
+    Remove a custom tag handler.
+    """
     assert isinstance(tag_name, basestring)
     del _serializers[tag_name]
+
+
+def tag(tag_name):
+    """
+    Decorator for a function or a class to use as a tagged element.
+
+    Example:
+
+        @tag("dog")
+        def parse_dog(name):
+            return {
+                "kind": "dog",
+                "name": name,
+                "message": "woof-woof",
+            }
+
+        parse("#dog \"Max\"")
+        # => {"kind": "dog", "name": "Max", "message": "woof-woof"}
+    """
+
+    def _tag_decorator(fn_or_cls):
+        _serializers[tag_name] = fn_or_cls
+        return fn_or_cls
+    return _tag_decorator
 
 
 def p_term_leaf(p):


### PR DESCRIPTION
This adds an `edn_format.tag` decorator as a shortcut for `add_tag`:

Before:
```python
def parse_dog(name):
    return {
        "kind": "dog",
        "name": name,
        "message": "woof-woof",
    }

edn_format.add_tag("dog", parse_dog)
```

After:
```python
@edn_format.tag("dog")
def parse_dog(name):
    return {
        "kind": "dog",
        "name": name,
        "message": "woof-woof",
    }
```

I also added some docs and tests.