### PR TITLE
Add edn_format.loads_all to parse all expressions in a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Implements the [EDN format](https://github.com/edn-format/edn) in Python.
 '#{1 2 3}'
 >>> edn_format.loads("[1 true nil]")
 [1, True, None]
+>>> edn_format.loads_all("1 2 3 4")
+[1, 2, 3, 4]
 ```
 
 

--- a/edn_format/__init__.py
+++ b/edn_format/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .edn_lex import Keyword, Symbol
-from .edn_parse import parse as loads
+from .edn_parse import parse as loads, parse_all as loads_all
 from .edn_parse import add_tag, remove_tag, tag, TaggedElement
 from .edn_dump import dump as dumps
 from .exceptions import EDNDecodeError
@@ -19,6 +19,7 @@ __all__ = (
     'add_tag',
     'dumps',
     'loads',
+    'loads_all',
     'remove_tag',
     'tag',
 )

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -24,7 +24,7 @@ if sys.version_info[0] == 3:
 if tokens:
     pass
 
-start = 'expression'
+start = 'expressions'
 
 _serializers = {}
 
@@ -180,7 +180,10 @@ def p_error(p):
         raise EDNDecodeError(p)
 
 
-def parse(text, input_encoding='utf-8'):
+def parse_all(text, input_encoding='utf-8'):
+    """
+    Parse all objects from the text and return a (possibly empty) list.
+    """
     if not isinstance(text, unicode):
         text = text.decode(input_encoding)
 
@@ -188,4 +191,13 @@ def parse(text, input_encoding='utf-8'):
     if __debug__:
         kwargs = dict(debug=True)
     p = ply.yacc.yacc(**kwargs)
-    return p.parse(text, lexer=lex())
+    expressions = p.parse(text, lexer=lex())
+    return list(expressions)
+
+
+def parse(text, input_encoding='utf-8'):
+    """
+    Parse one object from the text. Return None if the text is empty.
+    """
+    expressions = parse_all(text, input_encoding=input_encoding)
+    return expressions[0] if expressions else None


### PR DESCRIPTION
This mirrors `clojure.edn/read-string`’ that returns `nil` on empty strings, instead of failing on an EOF error.

As I understand the [edn spec](https://github.com/edn-format/edn), the input can (should?) be treated as a stream of values rather than only a single value:

> A use of edn might be a stream or file containing elements […].
>
> There is no enclosing element at the top level. Thus edn is suitable for streaming and interactive applications.