### PR TITLE
Parse hexadecimal notation

### DIFF
--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -215,7 +215,9 @@ def t_RATIO(t):
 
 
 def t_INTEGER(t):
-    r"""[+-]?\d+N?"""
+    # "No integer other than 0 may begin with 0."
+    # https://github.com/edn-format/edn#integers
+    r"""[+-]?(?:0|[1-9]\d*)N?"""
     if t.value.endswith('N'):
         t.value = t.value[:-1]
     t.value = int(t.value)

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -94,6 +94,7 @@ tokens = ('WHITESPACE',
           'CHAR',
           'STRING',
           'INTEGER',
+          'HEX_INTEGER',
           'FLOAT',
           'RATIO',
           'SYMBOL',
@@ -217,10 +218,16 @@ def t_RATIO(t):
 def t_INTEGER(t):
     # "No integer other than 0 may begin with 0."
     # https://github.com/edn-format/edn#integers
-    r"""[+-]?(?:0|[1-9]\d*)N?"""
+    r"""[+-]?(?:0(?!x)|[1-9]\d*)N?"""
     if t.value.endswith('N'):
         t.value = t.value[:-1]
     t.value = int(t.value)
+    return t
+
+
+def t_HEX_INTEGER(t):
+    r"""[+-]?0x[A-F0-9]+"""
+    t.value = int(t.value, 16)
     return t
 
 

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -77,6 +77,7 @@ def tag(tag_name):
 def p_term_leaf(p):
     """term : CHAR
             | STRING
+            | HEX_INTEGER
             | INTEGER
             | FLOAT
             | KEYWORD

--- a/tests.py
+++ b/tests.py
@@ -38,6 +38,8 @@ class EdnTest(unittest.TestCase):
                        "true")
         self.check_lex("[LexToken(INTEGER,123,1,0)]",
                        "123")
+        self.check_lex("[LexToken(HEX_INTEGER,1,1,0)]",
+                       "0x1")
         self.check_lex(
             "[LexToken(INTEGER,456,1,0), " +
             "LexToken(SYMBOL,None,1,4), " +
@@ -93,6 +95,8 @@ class EdnTest(unittest.TestCase):
     def test_parser_single_expressions(self):
         for expected, edn_string in (
             (1, "1"),
+            (16768115, "0xFFDC73"),
+            (Symbol("xFF"), "xFF"),
             (Symbol("a*b"), 'a*b'),
             ("ab", '"ab"'),
             ('a"b', r'"a\"b"'),
@@ -138,6 +142,7 @@ class EdnTest(unittest.TestCase):
             ([], "              ,,,,          ,, ,     "),
             ([1], ",,,,,,,1,,,,,,,,,"),
             ([1, 2], "1 2"),
+            ([0, Symbol("x1"), 1], "0 x1 0x1"),
             ([1, 2], "1                    2"),
             ([True, 42, False, Symbol('end')], "true 42 false end"),
             ([Symbol("a*b"), 42], 'a*b 42'),


### PR DESCRIPTION
Also, disallow 0-prefixed integers such as `0644` per the spec:

> No integer other than 0 may begin with 0. 64-bit (signed integer) precision is expected.


I had to add a negative lookahead in the `t_INTEGER` regexp so that `0xABC` is not parsed as `0 xABC`. The current implementation allows an integer to be followed by a symbol or a keyword:
```pycon
>>> edn_format.loads_all("123abc")
[123, Symbol(abc)]
>>> edn_format.loads_all("123NNN")
[123, Symbol(NN)]
>>> edn_format.loads_all("123:abc")
[123, Keyword(abc)]
```
The spec doesn’t explicitely say this is incorrect (emphasis mine):

> Elements are _generally_ separated by whitespace.

This fixes https://github.com/swaroopch/edn_format/issues/62.