### PR TITLE
Add indent parameter to edn_format.dumps()

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -56,6 +56,16 @@ def unicode_escape(string):
 
 
 def indent_lines(lines, open_sym, close_sym, indent, indent_step):
+    """
+    Indents a data structure.
+
+    ``lines`` is an array of strings composed of each element of the data
+    structure. ``open_sym`` and ``close_sym`` are strings representing the
+    opening and closing symbol of the data structure (i.e.: for a dict it
+    would be '{' and '}', respectively). ``indent`` is an integer representing
+    the number of spaces used to indent. ``indent_step`` is an integer
+    representing the current level of indentation.
+    """
     indent_prev = indent_step
     indent_step = indent_prev + indent
     # open symbol should be in the same line as current one
@@ -81,7 +91,19 @@ def udump(obj,
           sort_sets=False,
           indent=None,
           indent_step=0):
+    """
+    Dumps a formatted representation of a Python object.
 
+    ``string_encoding`` (defaults to 'utf-8') is the encoding to be used if the
+    object are bytes instead of strings. ``keyword_keys`` when True (defaults
+    to False) converts the keys from a dict from string to keywords.
+    ``sort_keys`` when True (defaults to False) sort dict keys alphabetically.
+    ``sort_sets`` when True (defaults to False) sort sets alphabetically.
+    ``indent`` when set to an positive integer (defaults to None) represents
+    the number of spaces used to indent the object. ``indent_step`` (defaults
+    to 0) represents the current indentation level when ``indent`` is different
+    from None.
+    """
     kwargs = {
         "string_encoding": string_encoding,
         "keyword_keys": keyword_keys,

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -71,7 +71,7 @@ def indent_lines(lines, open_sym, close_sym, indent, indent_step):
 
 
 def seq(obj, **kwargs):
-    return ' '.join([udump(i, **kwargs) for i in obj])
+    return [udump(i, **kwargs) for i in obj]
 
 
 def udump(obj,
@@ -109,13 +109,13 @@ def udump(obj,
     elif isinstance(obj, basestring):
         return unicode_escape(obj)
     elif isinstance(obj, tuple):
-        lines = [udump(o, **kwargs) for o in obj]
+        lines = seq(obj, **kwargs)
         if indent is None:
             return '({})'.format(' '.join(lines))
         else:
             return indent_lines(lines, '(', ')', indent, indent_step)
     elif isinstance(obj, (list, ImmutableList)):
-        lines = [udump(o, **kwargs) for o in obj]
+        lines = seq(obj, **kwargs)
         if indent is None:
             return '[{}]'.format(' '.join(lines))
         else:
@@ -124,7 +124,7 @@ def udump(obj,
         if sort_sets:
             obj = sorted(obj)
 
-        lines = [udump(o, **kwargs) for o in obj]
+        lines = seq(obj, **kwargs)
         if indent is None:
             return '#{{{}}}'.format(' '.join(lines))
         else:
@@ -138,7 +138,7 @@ def udump(obj,
         if keyword_keys:
             pairs = ((Keyword(k) if isinstance(k, (bytes, basestring)) else k, v) for k, v in pairs)
 
-        lines = [seq(p, **kwargs) for p in pairs]
+        lines = [' '.join(seq(p, **kwargs)) for p in pairs]
         if indent is None:
             return '{{{}}}'.format(' '.join(lines))
         else:

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -68,13 +68,13 @@ def indent_lines(lines, open_sym, close_sym, indent, indent_step):
     """
     indent_prev = indent_step
     indent_step = indent_prev + indent
-    # open symbol should be in the same line as current one
+    # open symbol should not be indented
     result = [open_sym]
 
     indent_spaces = indent_step * ' '
     result += [indent_spaces + line for line in lines]
 
-    # close symbol should be indented one line before the current one
+    # close symbol should be indented using the previous indentation level
     result += [indent_prev * ' ' + close_sym]
 
     return '\n'.join(result)
@@ -99,7 +99,7 @@ def udump(obj,
     to False) converts the keys from a dict from string to keywords.
     ``sort_keys`` when True (defaults to False) sort dict keys alphabetically.
     ``sort_sets`` when True (defaults to False) sort sets alphabetically.
-    ``indent`` when set to an positive integer (defaults to None) represents
+    ``indent`` when set to a positive integer (defaults to None) represents
     the number of spaces used to indent the object. ``indent_step`` (defaults
     to 0) represents the current indentation level when ``indent`` is different
     from None.

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -71,11 +71,11 @@ def indent_lines(lines, open_sym, close_sym, indent, indent_step):
     # open symbol should be in the same line as current one
     result = [open_sym]
 
-    for line in lines:
-        result.append(indent_step * ' ' + line)
+    indent_spaces = indent_step * ' '
+    result += [indent_spaces + line for line in lines]
 
     # close symbol should be indented one line before the current one
-    result.append(indent_prev * ' ' + close_sym)
+    result += [indent_prev * ' ' + close_sym]
 
     return '\n'.join(result)
 


### PR DESCRIPTION
This adds a pretty printer similar to `json.dumps(indent=<int>)`. However, it does not follow Clojure formatting guidelines, instead formatting in a way more common to users from other languages like Python.

So it will convert this:

```clojure
{"a": 1, "b": (1, 2, 3), "c": {"d": [1, 2, 3]}, "e": {1, 2, 3}}
```

To this:

```clojure
{
  :a 1
  :b (
    1
    2
    3
  )
  :c {
    :d [
      1
      2
      3
    ]
  }
  :e #{
    1
    2
    3
  }
}
```

Instead of this:

```clojure
{:a 1,
 :b (1
     2
     3),
 :c {:d [1
         2
         3]},
 :e #{1
      2
      3}}
```

This should be already better than the current status quo (that is, no pretty printer at all).

Should fix issue https://github.com/swaroopch/edn_format/issues/39 (unless the author of the issue wanted a more Clojure-like pretty printer).

Alternative implementation of PR https://github.com/swaroopch/edn_format/pull/64. It fixes all issues found by @bfontaine, and also this approach is simpler. However, different of the older approach this one also brings change in the non-indent flow, and it may be slower (however I think the difference will be insignificant).