### PR TITLE
setup.py: read requirements.txt directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
-try:
-    from pip.req import parse_requirements
-except ImportError:
-    from pip._internal.req import parse_requirements
+with open("requirements.txt") as f:
+    requirements = f.read().strip().split("\n")
 
-requirements = [str(ir.req) for ir in parse_requirements('requirements.txt', session=False)]
 
 setup(name="edn_format",
       version="0.7.1",


### PR DESCRIPTION
pip’s internal API is unsupported and may break anytime, like it just did.

See: https://stackoverflow.com/a/49837302/735926

Fixes #74.

