### PR TITLE
Add a Char class

### DIFF
--- a/edn_format/__init__.py
+++ b/edn_format/__init__.py
@@ -8,14 +8,16 @@ from .edn_dump import dump as dumps
 from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 from .immutable_list import ImmutableList
+from .char import Char
 
 __all__ = (
     'ImmutableList',
-    'EDNDecodeError',
     'ImmutableDict',
     'Keyword',
     'Symbol',
+    'Char',
     'TaggedElement',
+    'EDNDecodeError',
     'add_tag',
     'dumps',
     'loads',

--- a/edn_format/char.py
+++ b/edn_format/char.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+class Char(str):
+    """
+    This class represents a one-character string.
+    """
+    def __new__(cls, content):
+        assert len(content) == 1, "Char can only contain one character."
+        return super(Char, cls).__new__(cls, content)

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -15,6 +15,7 @@ import ply.lex
 
 from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
+from .char import Char
 
 
 if sys.version_info[0] == 3:
@@ -201,13 +202,14 @@ t_ignore = ''.join([" ", "\t", "\n", ","])
 def t_WHITESPACE(t):
     r"(\\newline)|(\\return)|(\\space)|(\\tab)"
     if t.value == r"\newline":
-        t.value = "\n"
+        t.value = Char("\n")
     elif t.value == r"\return":
-        t.value = "\r"
+        t.value = Char("\r")
     elif t.value == r"\space":
-        t.value = " "
+        t.value = Char(" ")
     elif t.value == r"\tab":
-        t.value = "\t"
+        t.value = Char("\t")
+
     return t
 
 
@@ -215,7 +217,7 @@ def t_CHAR(t):
     # uXXXX hex code or from "!" to "~" = all printable ASCII chars except the space
     # or unicode word chars
     r"(\\u[0-9A-Fa-f]{4}|\\[!-~\w])"
-    t.value = (t.value[1] if len(t.value) == 2 else _bytes(t.value).decode('raw_unicode_escape'))
+    t.value = Char(t.value[1] if len(t.value) == 2 else _bytes(t.value).decode('raw_unicode_escape'))
     return t
 
 


### PR DESCRIPTION
This PR adds a `Char` class, in order to fix the last item of #31.

* When reading EDN, chars are parsed as `Char` instances
* When dumping EDN, `Char` instances are dumped as EDN chars

`Char` inherits from `str`, so this is backward compatible.

```python
# both expressions are true
Char("c") == "c"
isinstance(Char("c"), str)
```

In fact, unless you explicitely test it with `isinstance(c, Char)`, a `Char` is indistinguishable from a one-char `str`.