### PR TITLE
Fix code and tests for Python 2

### DIFF
--- a/edn_format/char.py
+++ b/edn_format/char.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import sys
-
-if sys.version_info[0] == 3:
-    unicode = str
+from .compat import unicode
 
 
 class Char(unicode):

--- a/edn_format/char.py
+++ b/edn_format/char.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
-class Char(str):
+import sys
+
+if sys.version_info[0] == 3:
+    unicode = str
+
+
+class Char(unicode):
     """
     This class represents a one-character string.
     """

--- a/edn_format/compat.py
+++ b/edn_format/compat.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import sys
+
+_PY3 = sys.version_info[0] == 3
+
+# alias Python 2 types to their corresponding types in Python 3 if necessary
+if _PY3:
+    long = int
+    basestring = str
+    unicode = str
+    unichr = chr
+    def _bytes(s): return bytes(s, 'utf-8')
+else:
+    long = long
+    basestring = basestring
+    unicode = unicode
+    unichr = unichr
+    _bytes = bytes

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -16,16 +16,7 @@ from .char import Char
 from .edn_lex import Keyword, Symbol
 from .edn_parse import TaggedElement
 
-
-# alias Python 2 types to their corresponding types in Python 3 if necessary
-if sys.version_info[0] >= 3:
-    __PY3 = True
-    long = int
-    basestring = str
-    unicode = str
-    unichr = chr
-else:
-    __PY3 = False
+from .compat import _PY3, long, basestring, unicode, unichr
 
 
 DEFAULT_INPUT_ENCODING = 'utf-8'
@@ -216,6 +207,6 @@ def dump(obj,
                     sort_keys=sort_keys,
                     sort_sets=sort_sets,
                     indent=indent)
-    if __PY3:
+    if _PY3:
         return outcome
     return outcome.encode(output_encoding)

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -72,7 +72,8 @@ def dump_char(c):
         return SPECIAL_CHARS[c]
 
     # [2:] to strip the '0x' prefix
-    return "\\u{}".format(hex(ord(c))[2:].upper().rjust(4, "0"))
+    # str("0") because it must be an str and not a unicode in Python 2.
+    return "\\u{}".format(hex(ord(c))[2:].upper().rjust(4, str("0")))
 
 
 def indent_lines(lines, open_sym, close_sym, indent, indent_step):

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -17,14 +17,7 @@ from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 from .char import Char
 
-
-if sys.version_info[0] == 3:
-    long = int
-    basestring = str
-    unicode = str
-    def _bytes(s): return bytes(s, 'utf-8')
-else:
-    _bytes = bytes
+from .compat import unicode, _bytes
 
 
 ESCAPE_SEQUENCE_RE = re.compile(r'''

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -14,11 +14,7 @@ from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 from .immutable_list import ImmutableList
 
-
-if sys.version_info[0] == 3:
-    long = int
-    basestring = str
-    unicode = str
+from .compat import basestring, unicode
 
 # Dummy statement to indicate that 'tokens' is used.
 if tokens:

--- a/tests.py
+++ b/tests.py
@@ -17,9 +17,7 @@ from edn_format import edn_lex, edn_parse, \
     TaggedElement, add_tag, remove_tag, tag, \
     EDNDecodeError
 
-is_python3 = sys.version_info[0] == 3
-if is_python3:
-    unicode = str
+from edn_format.compat import _PY3, unicode
 
 
 class ConsoleTest(unittest.TestCase):
@@ -72,7 +70,7 @@ class EdnTest(unittest.TestCase):
             "LexToken(SYMBOL,None,1,4), " +
             "LexToken(SYMBOL,False,1,8)]",
             "456 nil false")
-        self.check_lex("[LexToken(CHAR,'c',1,0)]" if is_python3 else "[LexToken(CHAR,u'c',1,0)]",
+        self.check_lex("[LexToken(CHAR,'c',1,0)]" if _PY3 else "[LexToken(CHAR,u'c',1,0)]",
                        r"\c")
         self.check_lex("[LexToken(KEYWORD,Keyword(abc),1,0)]",
                        r":abc")

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@
 
 from collections import OrderedDict
 from uuid import uuid4, UUID
+import sys
 import random
 import datetime
 import fractions
@@ -15,6 +16,10 @@ from edn_format import edn_lex, edn_parse, \
     loads, dumps, Keyword, Symbol, ImmutableDict, ImmutableList, Char, \
     TaggedElement, add_tag, remove_tag, tag, \
     EDNDecodeError
+
+is_python3 = sys.version_info[0] == 3
+if is_python3:
+    unicode = str
 
 
 class ConsoleTest(unittest.TestCase):
@@ -67,7 +72,7 @@ class EdnTest(unittest.TestCase):
             "LexToken(SYMBOL,None,1,4), " +
             "LexToken(SYMBOL,False,1,8)]",
             "456 nil false")
-        self.check_lex("[LexToken(CHAR,'c',1,0)]",
+        self.check_lex("[LexToken(CHAR,'c',1,0)]" if is_python3 else "[LexToken(CHAR,u'c',1,0)]",
                        r"\c")
         self.check_lex("[LexToken(KEYWORD,Keyword(abc),1,0)]",
                        r":abc")
@@ -336,7 +341,7 @@ class EdnTest(unittest.TestCase):
     def check_char(self, expected, name):
         edn_data = "\\{}".format(name)
         parsed = loads(edn_data)
-        self.assertIsInstance(parsed, str)
+        self.assertIsInstance(parsed, unicode)
         self.assertEqual(expected, parsed, edn_data)
 
         self.assertIsInstance(parsed, Char)


### PR DESCRIPTION
I merged #77 and released, but saw _after_ that the tests are failing on Python 2 due to encoding issues: unicode characters can’t be encoded in `str`; it needs to be `unicode`. 😭 

So `Char` must subclass `unicode` in Python 2, rather than `str`.