### PR TITLE
Fix sort_sets when values are keywords or complex structures

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -157,7 +157,7 @@ def udump(obj,
             return indent_lines(lines, '[', ']', indent, indent_step)
     elif isinstance(obj, (set, frozenset)):
         if sort_sets:
-            obj = sorted(obj)
+            obj = sorted(obj, key=lambda v: str(v))
 
         lines = seq(obj, **kwargs)
         if indent is None:

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -72,6 +72,47 @@ class Keyword(BaseEdnType):
     def __str__(self):
         return ':{}'.format(self.name)
 
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        if not isinstance(other, Keyword):
+            return False
+        return self.name == other.name
+
+    def __cmp__(self, other):
+        if not isinstance(other, Keyword):
+            return NotImplemented
+        if self.name < other.name:
+            return -1
+        if self.name > other.name:
+            return +1
+        return 0
+
+    def __lt__(self, other):
+        cmp = self.__cmp__(other)
+        if cmp is NotImplemented:
+            return NotImplemented
+        return cmp < 0
+
+    def __le__(self, other):
+        cmp = self.__cmp__(other)
+        if cmp is NotImplemented:
+            return NotImplemented
+        return cmp <= 0
+
+    def __gt__(self, other):
+        cmp = self.__cmp__(other)
+        if cmp is NotImplemented:
+            return NotImplemented
+        return cmp > 0
+
+    def __ge__(self, other):
+        cmp = self.__cmp__(other)
+        if cmp is NotImplemented:
+            return NotImplemented
+        return cmp >= 0
+
     @property
     def namespace(self):
         """


### PR DESCRIPTION
## Context

Currently, dumping with `sort_sets=True` will fail when values are keywords or complex structures:

```python
import edn_format

obj = edn_format.loads(
    r"""#{:a :b :c #{:a :b}}""")

print(
    edn_format.dumps(
        obj,
        sort_sets=True))
```

## Solution

1. Add magic comparison methods to `Keyword`. I added both `__cmp__` and the other ones so it is compatible with python 2 and 3.
2. Sort the set's values when serializing by the serialized value ([like the dict does](https://github.com/swaroopch/edn_format/blob/2a545f5969738cff7533eba611cd0ecafd65ab86/edn_format/edn_dump.py#L171))