### PR TITLE
CI: bump Ubuntu; test on 3.13; drop 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 20.04 is no longer provided, and Python 3.6 is not available on Ubuntu 22.04 runners: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json