### PR TITLE
Fix t_HEX_INTEGER to accept lower-case digits a-f

### DIFF
--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -256,7 +256,7 @@ def t_INTEGER(t):
 
 
 def t_HEX_INTEGER(t):
-    r"""[+-]?0x[A-F0-9]+"""
+    r"""[+-]?0x[0-9A-Fa-f]+"""
     t.value = int(t.value, 16)
     return t
 


### PR DESCRIPTION
This PR fixes the PLY regex for HEX_INTEGER to accept lower-case hexadecimal digits. Not doing so results in hex numbers being split as separate integers and symbols