### PR TITLE
Add support for Clojure metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `edn_format` Changelog
 
+## Unreleased
+
+* Add support for EDN metadata (`^{...} value`). A new `MetadataValue` class
+  wraps a value with its metadata; the lexer recognizes `^` as a metadata
+  prefix and the parser produces `MetadataValue` instances. `dumps` serializes
+  `MetadataValue` back to the canonical `^M V` form.
+
 ## v0.7.5 (2020/11/06)
 
 * No changes to library code

--- a/edn_format/__init__.py
+++ b/edn_format/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from .edn_lex import Keyword, Symbol
+from .edn_lex import Keyword, MetadataValue, Symbol
 from .edn_parse import parse as loads, parse_all as loads_all
 from .edn_parse import add_tag, remove_tag, tag, TaggedElement
 from .edn_dump import dump as dumps
@@ -14,6 +14,7 @@ __all__ = (
     'ImmutableList',
     'ImmutableDict',
     'Keyword',
+    'MetadataValue',
     'Symbol',
     'Char',
     'TaggedElement',

--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -12,7 +12,7 @@ import pyrfc3339
 from .immutable_dict import ImmutableDict
 from .immutable_list import ImmutableList
 from .char import Char
-from .edn_lex import Keyword, Symbol
+from .edn_lex import Keyword, MetadataValue, Symbol
 from .edn_parse import TaggedElement
 
 from .compat import _PY3, long, basestring, unicode, unichr
@@ -124,7 +124,14 @@ def udump(obj,
         "indent_step": indent_step + (indent or 0),
     }
 
-    if obj is None:
+    if isinstance(obj, MetadataValue):
+        # EDN metadata `^M V`. Both metadata and value serialize at the same
+        # nesting depth as the MetadataValue itself (don't bump indent_step).
+        same_level = dict(kwargs, indent_step=indent_step)
+        meta_str = udump(obj.metadata, **same_level)
+        value_str = udump(obj.value, **same_level)
+        return '^{} {}'.format(meta_str, value_str)
+    elif obj is None:
         return 'nil'
     elif isinstance(obj, bool):
         return 'true' if obj else 'false'

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -124,20 +124,17 @@ class MetadataValue(object):
 
     def __eq__(self, other):
         if not isinstance(other, MetadataValue):
-            return False
-        return self.metadata == other.metadata and self.value == other.value
+            return other == self.value
+        return self.value == other.value
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        meta = (ImmutableDict(self.metadata)
-                if isinstance(self.metadata, dict)
-                else self.metadata)
-        return hash((MetadataValue, meta, self.value))
+        return hash(self.value)
 
     def __repr__(self):
-        return 'MetadataValue({!r}, {!r})'.format(self.metadata, self.value)
+        return '{}({!r}, {!r})'.format(self.__class__.__name__, self.metadata, self.value)
 
 
 # http://www.dabeaz.com/ply/ply.html

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -113,6 +113,33 @@ class Symbol(BaseEdnType):
         return self._name
 
 
+class MetadataValue(object):
+    """An EDN value annotated with metadata, serialized as ``^{metadata} value``."""
+
+    __slots__ = ('metadata', 'value')
+
+    def __init__(self, metadata, value):
+        self.metadata = metadata
+        self.value = value
+
+    def __eq__(self, other):
+        if not isinstance(other, MetadataValue):
+            return False
+        return self.metadata == other.metadata and self.value == other.value
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        meta = (ImmutableDict(self.metadata)
+                if isinstance(self.metadata, dict)
+                else self.metadata)
+        return hash((MetadataValue, meta, self.value))
+
+    def __repr__(self):
+        return 'MetadataValue({!r}, {!r})'.format(self.metadata, self.value)
+
+
 # http://www.dabeaz.com/ply/ply.html
 tokens = ('WHITESPACE',
           'CHAR',
@@ -132,7 +159,8 @@ tokens = ('WHITESPACE',
           'MAP_OR_SET_END',
           'TAG',
           'DISCARD_TAG',
-          'MAP_NAMESPACE_TAG')
+          'MAP_NAMESPACE_TAG',
+          'CARET')
 
 PARTS = {}
 PARTS["non_nums"] = r"\w.*+!\-_?$%&=:#<>@"
@@ -188,6 +216,7 @@ t_LIST_END = r'\)'
 t_MAP_START = r'\{'
 t_SET_START = r'\#\{'
 t_MAP_OR_SET_END = r'\}'
+t_CARET = r'\^'
 t_ignore = ''.join([" ", "\t", "\n", ","])
 
 

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -8,7 +8,7 @@ from collections import deque
 import ply.yacc
 import pyrfc3339
 
-from .edn_lex import tokens, lex, Keyword
+from .edn_lex import tokens, lex, Keyword, MetadataValue
 from .exceptions import EDNDecodeError
 from .immutable_dict import ImmutableDict
 from .immutable_list import ImmutableList
@@ -194,6 +194,11 @@ def p_expression_tagged_element(p):
             u"Don't know how to handle tag ImmutableDict({})".format(tag))
 
     p[0] = output
+
+
+def p_expression_metadata(p):
+    """expression : CARET expression expression"""
+    p[0] = MetadataValue(metadata=p[2], value=p[3])
 
 
 def eof():

--- a/tests.py
+++ b/tests.py
@@ -719,8 +719,13 @@ class MetadataTest(unittest.TestCase):
         a = MetadataValue({Keyword("x"): 1}, [1, 2])
         b = MetadataValue({Keyword("x"): 1}, [1, 2])
         self.assertEqual(a, b)
+        # metadata is transparent: two MetadataValues with the same wrapped value
+        # compare equal regardless of differing metadata annotations
         c = MetadataValue({Keyword("x"): 2}, [1, 2])
-        self.assertNotEqual(a, c)
+        self.assertEqual(a, c)
+        # transparent comparison with the raw value
+        self.assertEqual(a, [1, 2])
+        self.assertNotEqual(a, [1, 2, 3])
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -13,7 +13,7 @@ import pytz
 
 from edn_format import edn_lex, edn_parse, \
     loads, dumps, Keyword, Symbol, ImmutableDict, ImmutableList, Char, \
-    TaggedElement, add_tag, remove_tag, tag, \
+    MetadataValue, TaggedElement, add_tag, remove_tag, tag, \
     EDNDecodeError
 
 from edn_format.compat import _PY3, unicode
@@ -110,6 +110,13 @@ class EdnTest(unittest.TestCase):
                        "LexToken(MAP_START,'{',1,3), "
                        "LexToken(MAP_OR_SET_END,'}',1,4)]",
                        "#:a{}")
+        self.check_lex("[LexToken(CARET,'^',1,0), "
+                       "LexToken(MAP_START,'{',1,1), "
+                       "LexToken(MAP_OR_SET_END,'}',1,2), "
+                       "LexToken(VECTOR_START,'[',1,4), "
+                       "LexToken(INTEGER,1,1,5), "
+                       "LexToken(VECTOR_END,']',1,6)]",
+                       "^{} [1]")
 
     def check_parse(self, expected_output, actual_input):
         self.assertEqual(expected_output, edn_parse.parse(actual_input),
@@ -169,6 +176,27 @@ class EdnTest(unittest.TestCase):
             ({Keyword("bar/k"): 42}, "#:foo{:bar/k 42}"),
             ({Keyword("foo/k"): 42}, "#:foo{:k 42}"),
             ({Keyword("foo/k"): {Keyword("k"): 1}}, "#:foo{:k {:k 1}}"),
+
+            (MetadataValue(ImmutableDict({Keyword("tag"): Keyword("foo")}),
+                           ImmutableList([1, 2, 3])),
+                "^{:tag :foo} [1 2 3]"),
+            (MetadataValue(ImmutableDict({}), ImmutableList([1, 2])),
+                "^{} [1 2]"),
+            (ImmutableList([
+                MetadataValue(ImmutableDict({Keyword("a"): 1}),
+                              ImmutableDict({})),
+                MetadataValue(ImmutableDict({Keyword("b"): 2}),
+                              ImmutableList([])),
+             ]),
+                "[^{:a 1} {} ^{:b 2} []]"),
+            (MetadataValue(
+                ImmutableDict({Keyword("meta"): MetadataValue(
+                    ImmutableDict({Keyword("inner"): True}),
+                    ImmutableDict({}))}),
+                Keyword("foo")),
+                "^{:meta ^{:inner true} {}} :foo"),
+            # `^` inside a string literal is not metadata syntax.
+            ("^not-meta", '"^not-meta"'),
         ):
             self.check_parse(expected, edn_string)
             self.check_parse_all([expected], edn_string)
@@ -312,6 +340,8 @@ class EdnTest(unittest.TestCase):
             r"\newline",
             r"\tab",
             r"\uAA0A",
+            "^{:tag :foo} [1 2 3]",
+            "^{} [1 2]",
         )
 
         class TagDate(TaggedElement):
@@ -652,6 +682,45 @@ class CharTest(unittest.TestCase):
 
     def test_new_fail(self):
         self.assertRaises(AssertionError, lambda: Char("some string"))
+
+
+class MetadataTest(unittest.TestCase):
+    def test_dumps_simple_keyword_metadata(self):
+        obj = MetadataValue({Keyword("tag"): Keyword("foo")}, [1, 2, 3])
+        self.assertEqual(dumps(obj), "^{:tag :foo} [1 2 3]")
+
+    def test_dumps_empty_metadata_map(self):
+        obj = MetadataValue({}, [1, 2])
+        self.assertEqual(dumps(obj), "^{} [1 2]")
+
+    def test_dumps_metadata_on_map_value(self):
+        obj = MetadataValue({Keyword("source"): "test"},
+                            {Keyword("type"): Keyword("node")})
+        self.assertEqual(dumps(obj), '^{:source "test"} {:type :node}')
+
+    def test_dumps_metadata_nested_in_list(self):
+        inner = MetadataValue({Keyword("tag"): Keyword("x")},
+                              {Keyword("a"): 1})
+        obj = [inner, {Keyword("b"): 2}]
+        self.assertEqual(dumps(obj), "[^{:tag :x} {:a 1} {:b 2}]")
+
+    def test_dumps_metadata_on_keyword(self):
+        obj = MetadataValue({Keyword("doc"): "a keyword"}, Keyword("my-kw"))
+        self.assertEqual(dumps(obj), '^{:doc "a keyword"} :my-kw')
+
+    def test_dumps_metadata_with_indent(self):
+        # With indent set, the metadata map itself is multi-line formatted just
+        # like any other map: indentation is applied at every level uniformly.
+        obj = MetadataValue({Keyword("tag"): Keyword("foo")}, [1, 2])
+        self.assertEqual(dumps(obj, indent=2),
+                         "^{\n  :tag :foo\n} [\n  1\n  2\n]")
+
+    def test_metadata_value_equality(self):
+        a = MetadataValue({Keyword("x"): 1}, [1, 2])
+        b = MetadataValue({Keyword("x"): 1}, [1, 2])
+        self.assertEqual(a, b)
+        c = MetadataValue({Keyword("x"): 2}, [1, 2])
+        self.assertNotEqual(a, c)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While metadata isn't part of the core EDN spec, it is implemented in the Clojure reader and implemented in other edn handline libraries (e.g. [edn-ruby](https://github.com/relevance/edn-ruby))

This PR adds first-class support for serializing/parsing MetadataValue objects as clojure reader metadata `^{metadata} value`