### PR TITLE
Support EDN symbolic values (##Inf/##-Inf/##NaN) so non-finite floats round-trip

### DIFF
--- a/edn_format/edn_dump.py
+++ b/edn_format/edn_dump.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import decimal
 import fractions
+import math
 import re
 import uuid
 
@@ -135,6 +136,12 @@ def udump(obj,
         return 'nil'
     elif isinstance(obj, bool):
         return 'true' if obj else 'false'
+    elif isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+        # EDN symbolic values; https://clojure.org/reference/reader#_symbolic_values
+        # A bare `inf`/`nan` would read back as a Symbol, breaking round-tripping.
+        if math.isnan(obj):
+            return '##NaN'
+        return '##Inf' if obj > 0 else '##-Inf'
     elif isinstance(obj, (int, long, float)):
         return unicode(obj)
     elif isinstance(obj, decimal.Decimal):

--- a/edn_format/edn_lex.py
+++ b/edn_format/edn_lex.py
@@ -144,6 +144,7 @@ tokens = ('WHITESPACE',
           'INTEGER',
           'HEX_INTEGER',
           'FLOAT',
+          'SYMBOLIC_VALUE',
           'RATIO',
           'SYMBOL',
           'KEYWORD',
@@ -215,6 +216,15 @@ t_SET_START = r'\#\{'
 t_MAP_OR_SET_END = r'\}'
 t_CARET = r'\^'
 t_ignore = ''.join([" ", "\t", "\n", ","])
+
+
+def t_SYMBOLIC_VALUE(t):
+    # https://clojure.org/reference/reader#_symbolic_values
+    r"\#\#(-Inf|Inf|NaN)"
+    t.value = {"##Inf": float("inf"),
+               "##-Inf": float("-inf"),
+               "##NaN": float("nan")}[t.value]
+    return t
 
 
 def t_WHITESPACE(t):

--- a/edn_format/edn_parse.py
+++ b/edn_format/edn_parse.py
@@ -75,6 +75,7 @@ def p_term_leaf(p):
             | HEX_INTEGER
             | INTEGER
             | FLOAT
+            | SYMBOLIC_VALUE
             | KEYWORD
             | SYMBOL
             | RATIO

--- a/tests.py
+++ b/tests.py
@@ -403,6 +403,24 @@ class EdnTest(unittest.TestCase):
         ):
             self.assertEqual(edn_data, dumps(loads(edn_data)), edn_data)
 
+    def test_symbolic_values(self):
+        import math
+
+        # Parsing the EDN symbolic values yields the matching float.
+        self.assertEqual(float("inf"), loads("##Inf"))
+        self.assertEqual(float("-inf"), loads("##-Inf"))
+        self.assertTrue(math.isnan(loads("##NaN")))
+
+        # Dumping non-finite floats produces the symbolic values, so that
+        # round-tripping does not silently turn them into Symbols.
+        self.assertEqual("##Inf", dumps(float("inf")))
+        self.assertEqual("##-Inf", dumps(float("-inf")))
+        self.assertEqual("##NaN", dumps(float("nan")))
+
+        self.check_roundtrip(float("inf"))
+        self.check_roundtrip(float("-inf"))
+        self.assertTrue(math.isnan(loads(dumps(float("nan")))))
+
     def test_keyword_keys(self):
         unchanged = (
             None,


### PR DESCRIPTION
### Problem

`dumps()` silently corrupts non-finite floats. `inf`, `-inf`, and `nan` are emitted as the bare tokens `inf` / `-inf` / `nan`, which the reader then reads back as `Symbol` objects rather than floats:

```python
>>> import edn_format as e
>>> e.loads(e.dumps(float("inf")))
Symbol(inf)          # expected: inf
>>> e.loads("##Inf")
EDNDecodeError: Illegal character '#' ...
```

So `loads(dumps(x))` does not round-trip for non-finite floats (the repo's own `check_roundtrip` invariant), and the canonical EDN representation produced by Clojure (`##Inf` / `##-Inf` / `##NaN`) cannot be read at all.

### Fix

Support EDN's symbolic values, [`##Inf` / `##-Inf` / `##NaN`](https://clojure.org/reference/reader#_symbolic_values), on both paths:

- `edn_lex.py`: a `SYMBOLIC_VALUE` token (`\#\#(-Inf|Inf|NaN)`), defined ahead of the other `#` token rules so it takes lexer priority. It maps to the matching float.
- `edn_parse.py`: `SYMBOLIC_VALUE` added to the `p_term_leaf` rule.
- `edn_dump.py`: non-finite floats now dump to `##Inf` / `##-Inf` / `##NaN` instead of bare tokens.

Non-finite floats now round-trip, and `##Inf` / `##-Inf` / `##NaN` from real EDN parse correctly. The non-finite check uses `math.isnan` / `math.isinf` (available on Python 2.6+) to stay within the package's stated version support.

### Tests

Added `test_symbolic_values` to `EdnTest`, covering both parse and dump directions plus the existing `check_roundtrip` helper. It fails before the change (`EDNDecodeError`) and passes after. Full suite: 39 tests pass; `flake8 --max-line-length=100` clean. Existing `#`-dispatch syntax (`#{...}`, `#_`, `#inst`, `#uuid`, `#:ns{...}`) is unaffected.

I used an AI assistant to help investigate this under my direction, and I have reviewed and verified the change myself.
